### PR TITLE
imxrt1170-evk.json specs corrections

### DIFF
--- a/manifests/imxrt1170-evk.json
+++ b/manifests/imxrt1170-evk.json
@@ -15,15 +15,15 @@
         "manufacturer": "NXP",
         "specs": {
             "MCU": "i.MX RT1176xxA",
-            "RAM": "256 MB SRAM",
+            "RAM": "1 MB internal, 32 MB external",
             "Flash": "16 MB",
             "GPU": "PXP",
             "Resolution": "800x480",
-            "Display Size": "4.3”",
+            "Display Size": "7”",
             "Interface": "MIPI DSI",
             "Color Depth": "24-bit",
-            "Technology": "LCD",
-            "DPI": "128 px/inch",
+            "Technology": "IPS",
+            "DPI": "133 px/inch",
             "Touch Pad": "Capacitive"
         }
     },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Corrected imxrt1170-evk manifest specs to match the actual hardware. Updated RAM to 1 MB internal + 32 MB external, display size to 7", display technology to IPS, and DPI to 133.

<sup>Written for commit 896cfbe21b496cf05fb52c5d8ab494fc96ee7318. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

